### PR TITLE
Fix pydantic errors + update `docs_url`

### DIFF
--- a/service.py
+++ b/service.py
@@ -39,7 +39,7 @@ app = FastAPI(
         "name": "Biopython",
         "url": "https://github.com/biopython/biopython/blob/master/LICENSE.rst",
     },
-    docs_url="/api", # ONLY set when there is no default GET
+    docs_url="/docs", # ONLY set when there is no default GET
 )
 
 class ModeE(StrEnum):

--- a/service.py
+++ b/service.py
@@ -12,7 +12,7 @@ from utils import IVCAPRestService, IVCAPService, SchemaModel, StrEnum
 signal(SIGTERM, lambda _1, _2: sys.exit(0))
 
 title = "Pairwise sequence alignment"
-summary = "Aligs two sequences to each other by optimizing the similarity score between them.",
+summary = "Aligs two sequences to each other by optimizing the similarity score between them."
 description = """
 Pairwise sequence alignment
 
@@ -49,16 +49,16 @@ class ModeE(StrEnum):
 
 class Request(SchemaModel):
     SCHEMA: ClassVar[str] = "urn:sd.test:schema.fastapi-test.request.1"
-    target: str = Field(description="The target sequence as a string", examples="GAACT")
-    query: str = Field(description="The sequence to align as a string", examples="GAT")
+    target: str = Field(description="The target sequence as a string", examples=["GAACT"])
+    query: str = Field(description="The sequence to align as a string", examples=["GAT"])
     mode: ModeE = Field(ModeE.Local, description="Some decription on what a 'mode' means")
     match_score: float = Field(1.000000, description="Some decription on what a 'match_score' means")
     mismatch_score: float = Field(0.000000, description="Some decription on what a 'mismatch_score' means")
 
 class Response(SchemaModel):
     SCHEMA: ClassVar[str] = "urn:sd.test:schema.fastapi-test.response.1"
-    target: str = Field(description="The target sequence as a string", examples="GAACT")
-    query: str = Field(description="The sequence to align as a string", examples="GAT")
+    target: str = Field(description="The target sequence as a string", examples=["GAACT"])
+    query: str = Field(description="The sequence to align as a string", examples=["GAT"])
     alignments: List[List[List[List[int]]]] = Field(description="a list of alignments")
     score: float = Field(description="Overall score of the alignemnt?")
 


### PR DESCRIPTION
This PR has 2x minor updates:

1. Fixes a couple of issues in pydantic / service.py that were breaking the generation of openapi.json spec + swagger docs.

i.e. fixes these errors when attempting to access the docs:

```
pydantic_core._pydantic_core.ValidationError: 11 validation errors for OpenAPI
info.summary
  Input should be a valid string [type=string_type, input_value=('Aligs two sequences to ...y score between them.',), input_type=tuple]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
components.schemas.Request.Schema.properties.target.Schema.examples
  Input should be a valid list [type=list_type, input_value='GAACT', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/list_type
components.schemas.Request.Schema.properties.target.bool
  Input should be a valid boolean [type=bool_type, input_value={'description': 'The targ...rget', 'type': 'string'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/bool_type
components.schemas.Request.Schema.properties.query.Schema.examples
  Input should be a valid list [type=list_type, input_value='GAT', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/list_type
components.schemas.Request.Schema.properties.query.bool
  Input should be a valid boolean [type=bool_type, input_value={'description': 'The sequ...uery', 'type': 'string'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/bool_type
components.schemas.Request.Reference.$ref
  Field required [type=missing, input_value={'properties': {'$schema'...uest', 'type': 'object'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
components.schemas.Response.Schema.properties.target.Schema.examples
  Input should be a valid list [type=list_type, input_value='GAACT', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/list_type
components.schemas.Response.Schema.properties.target.bool
  Input should be a valid boolean [type=bool_type, input_value={'description': 'The targ...rget', 'type': 'string'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/bool_type
components.schemas.Response.Schema.properties.query.Schema.examples
  Input should be a valid list [type=list_type, input_value='GAT', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/list_type
components.schemas.Response.Schema.properties.query.bool
  Input should be a valid boolean [type=bool_type, input_value={'description': 'The sequ...uery', 'type': 'string'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/bool_type
components.schemas.Response.Reference.$ref
  Field required [type=missing, input_value={'properties': {'$schema'...onse', 'type': 'object'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
```

2. Updates FastAPI's `docs_url` to `/docs`, because this is where the FastAPI CLI tells you the docs are on startup:

```
INFO     Using import string service:app                                                                                                                      
                                                                                                                                                              
 ╭─────────── FastAPI CLI - Production mode ───────────╮                                                                                                      
 │                                                     │                                                                                                      
 │  Serving at: http://localhost:8096                  │                                                                                                      
 │                                                     │                                                                                                      
 │  API docs: http://localhost:8096/docs               │                                                                                                      
 │                                                     │                                                                                                      
 │  Running in production mode, for development use:   │                                                                                                      
 │                                                     │                                                                                                      
 │  fastapi dev                                        │                                                                                                      
 │                                                     │                                                                                                      
 ╰─────────────────────────────────────────────────────╯                                                                                                      
                                                                                                                                                              
INFO:     Started server process [68709]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8096 (Press CTRL+C to quit)
```