### PR TITLE
update Dockerfile to be compatible with `ivcap_fastapi` update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM python:3.11.9-slim-bookworm AS builder
 
 WORKDIR /app
+
+# Update package list and ensure we have git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 RUN pip install -U pip
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
 # Get service files
-ADD service.py utils.py try_later.py json_rpc.py ./
+ADD service.py utils.py ./
 
 # VERSION INFORMATION
 ARG VERSION ???


### PR DESCRIPTION
Fixes 2x issues with Dockerfile to be compatible with the `ivcap_fastapi` package:

1. don't try to add `try_later.py json_rpc.py` as they have been removed
2. ensure git is installed so we can use it to pip install `ivcap_fastapi`